### PR TITLE
Fix execution_timeout vs timeout_interval inconsistency

### DIFF
--- a/lib/attentive_sidekiq.rb
+++ b/lib/attentive_sidekiq.rb
@@ -23,7 +23,7 @@ module AttentiveSidekiq
     attr_writer :timeout_interval, :execution_interval, :logger
 
     def timeout_interval
-      return @execution_timeout if @execution_timeout
+      return @timeout_interval if @timeout_interval
       @timeout_interval = options[:timeout_interval] || DEFAULTS[:timeout_interval]
     end
 


### PR DESCRIPTION
The variable was inconsistenly named compared to the method name.

The correct name should be timeout_interval - this makes things
consistent with the rest of the code and with http://www.rubydoc.info/github/ruby-concurrency/concurrent-ruby/Concurrent/TimerTask