### PR TITLE
Enable reliable jobs using sidekiq options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ rdoc
 tmp
 *.swp
 *.rdb
+.idea

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ After that you can use your jobs as usual.
 
 Specify desired configuration inside of `sidekiq.yml` file:
 
+By default jobs will not be monitored, in order to enable monitoring of your job, you will need to add `:adblock_reliable => true` sidekiq option it e.g.
+```ruby
+sidekiq_options :queue => :accessibility, :retry => 3, :adblock_reliable => true
+```
+
+
 ```YML
 attentive:
   # Time in seconds between checks for disappeared jobs

--- a/lib/attentive_sidekiq/middleware/server/attentionist.rb
+++ b/lib/attentive_sidekiq/middleware/server/attentionist.rb
@@ -3,10 +3,16 @@ module AttentiveSidekiq
     module Server
       class Attentionist
         def call(worker_instance, item, queue)
-          Suspicious.add(item)
+          reliable_job = item["adblock_reliable"]
+
+          if reliable_job
+            AttentiveSidekiq.logger.info("AttentiveSidekiq will monitor job: #{item}")
+            Suspicious.add(item)
+          end
+
           yield
         ensure
-          Suspicious.remove(item['jid'])
+          Suspicious.remove(item['jid']) if reliable_job
         end
       end
     end


### PR DESCRIPTION
Enable selective monitoring of jobs using `:adblock_reliable` sidekiq option.

Be default jobs will not be monitored. If we want our job to be monitored we can add the sidekiq option `:adblock_reliable` to it.