### PR TITLE
Fix options not being accessed properly

### DIFF
--- a/lib/attentive_sidekiq.rb
+++ b/lib/attentive_sidekiq.rb
@@ -37,7 +37,10 @@ module AttentiveSidekiq
     end
 
     def options
-      Sidekiq.options[:attentive] || Sidekiq.options['attentive'] || {}
+      Sidekiq.default_configuration
+             .instance_variable_get(:@options)
+             .transform_keys(&:to_sym)
+             .try(:attentive) || {}
     end
   end
 end


### PR DESCRIPTION
With the introduction of capsules in Sidekiq the configuration structure of the gem radically changed. This PR introduces a **breaking change** to allow to fetch the configuration through the new structure.

I suggest that the configuration aspect of this gem changes too, as the current change proposed in this PR is hacky.

However I'm not sure how attentive sidekiq is going to work regarding capsules. Since the gem accesses redis directly it should be okay, however I'm not 100% convinced since I didn't pry enough in the source.